### PR TITLE
Compability with Flutter 2.8.0

### DIFF
--- a/lib/multiselect_formfield.dart
+++ b/lib/multiselect_formfield.dart
@@ -32,7 +32,7 @@ class MultiSelectFormField extends FormField<dynamic> {
     FormFieldSetter<dynamic>? onSaved,
     FormFieldValidator<dynamic>? validator,
     dynamic initialValue,
-    bool autovalidate = false,
+    AutovalidateMode autovalidate = AutovalidateMode.disabled,
     this.title = const Text('Title'),
     this.hintWidget = const Text('Tap to select one or more'),
     this.required = false,
@@ -62,7 +62,7 @@ class MultiSelectFormField extends FormField<dynamic> {
           onSaved: onSaved,
           validator: validator,
           initialValue: initialValue,
-          autovalidate: autovalidate,
+          autovalidateMode: autovalidate,
           builder: (FormFieldState<dynamic> state) {
             List<Widget> _buildSelectedOptions(state) {
               List<Widget> selectedOptions = [];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: multiselect_formfield
 description: A multi select form field using alert dialog to select multiple items with checkboxes and showing as chips.
-version: 0.1.6
+version: 0.1.7
 author: Carlos E. Torres <cetorres@cetorres.com>
 homepage: https://github.com/cetorres/multiselect_formfield
 


### PR DESCRIPTION
changes autovalidate to autovalidateMode property on FormField because of its removal in 2.8.0 after its deprecation, refering to https://github.com/flutter/flutter/pull/90292